### PR TITLE
Fix wallet signing and concurrent peer routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1435,9 +1435,9 @@
       "link": true
     },
     "node_modules/@leofcoin/peernet": {
-      "version": "1.2.22",
-      "resolved": "https://registry.npmjs.org/@leofcoin/peernet/-/peernet-1.2.22.tgz",
-      "integrity": "sha512-HHLd9ao07ueQxNT6BkgbqSfCu/qmu/dHOCVWQgWBoCz6ZyWk7gtJL2ZrWqy8Lo02qdKgEEldLWwTKB58UZ6urA==",
+      "version": "1.2.23",
+      "resolved": "https://registry.npmjs.org/@leofcoin/peernet/-/peernet-1.2.23.tgz",
+      "integrity": "sha512-8vwy0eaScroaYHC2ei4UpW77kZiSDWvT5XSvmm5Q5/jeMq16ovebGf1A3ElSk2kS8hMjH1BGb1d2z1mI5uuNUA==",
       "license": "MIT",
       "dependencies": {
         "@leofcoin/codec-format-interface": "^1.8.2",
@@ -1447,7 +1447,7 @@
         "@leofcoin/multi-wallet": "^3.1.8",
         "@leofcoin/storage": "^3.5.38",
         "@mapbox/node-pre-gyp": "^2.0.3",
-        "@netpeer/swarm": "^0.9.8",
+        "@netpeer/swarm": "^0.9.9",
         "@vandeurenglenn/base58": "^1.1.9",
         "@vandeurenglenn/debug": "^1.4.0",
         "@vandeurenglenn/little-pubsub": "^1.5.2",
@@ -1633,9 +1633,9 @@
       }
     },
     "node_modules/@netpeer/swarm": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@netpeer/swarm/-/swarm-0.9.8.tgz",
-      "integrity": "sha512-SQc53fL25x6+gIxUl7EL5XhV1h5Prcw3w11CJ7bNbbIg168h4eQdodLgB1FIV+7QN4GONxdDMXsmshcqjom2XA==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@netpeer/swarm/-/swarm-0.9.10.tgz",
+      "integrity": "sha512-glrpdtQTdsp8/qE0SFaADlF605iuPfj+5N+yW/SK/BuWTi7ijpDQEVzfTTg7efwlVXMX39x45emBnUXBznrUug==",
       "license": "MIT",
       "dependencies": {
         "@koush/wrtc": "^0.5.3",
@@ -1643,7 +1643,7 @@
         "@vandeurenglenn/little-pubsub": "^1.5.2",
         "pako": "^2.1.0",
         "socket-request-client": "^2.1.3",
-        "socket-request-server": "^1.7.2"
+        "socket-request-server": "^1.7.3"
       }
     },
     "node_modules/@noble/curves": {
@@ -8240,12 +8240,12 @@
       }
     },
     "node_modules/socket-request-server": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/socket-request-server/-/socket-request-server-1.7.2.tgz",
-      "integrity": "sha512-L6kIuXa05PidSQxrwnrWQQTL4o5rmZW9Imw3x4PL8qHOd1qXUTMH/iOf2isTkOs/Zygyc4LyzlsQiIqtOBKoEA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/socket-request-server/-/socket-request-server-1.7.4.tgz",
+      "integrity": "sha512-DwEN7JapVGLivN5IClS+TC7cZxX/AsFvQYOsrTuA9DqzUbfrBBbMce9pLKZrFiBV88X7mktkHkOx12tB+44tKQ==",
       "license": "MIT",
       "dependencies": {
-        "@vandeurenglenn/little-pubsub": "^1.5.1",
+        "@vandeurenglenn/little-pubsub": "^1.5.2",
         "websocket": "^1.0.35"
       }
     },
@@ -9250,7 +9250,7 @@
     },
     "packages/chain": {
       "name": "@leofcoin/chain",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "@leofcoin/addresses": "^1.0.59",
@@ -9258,11 +9258,11 @@
         "@leofcoin/contracts": "^0.1.20",
         "@leofcoin/crypto": "^0.2.40",
         "@leofcoin/errors": "^1.0.29",
-        "@leofcoin/lib": "^1.3.0",
+        "@leofcoin/lib": "^1.3.1",
         "@leofcoin/messages": "^1.6.0",
         "@leofcoin/multi-wallet": "^3.1.9",
         "@leofcoin/networks": "^1.1.29",
-        "@leofcoin/peernet": "^1.2.22",
+        "@leofcoin/peernet": "^1.2.23",
         "@leofcoin/storage": "^3.5.38",
         "@leofcoin/utils": "^1.1.43",
         "@leofcoin/workers": "^1.5.31",
@@ -9419,12 +9419,12 @@
     },
     "packages/lib": {
       "name": "@leofcoin/lib",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@leofcoin/addresses": "^1.0.59",
         "@leofcoin/messages": "^1.5.3",
-        "@leofcoin/peernet": "^1.2.22",
+        "@leofcoin/peernet": "^1.2.23",
         "@leofcoin/storage": "^3.5.38",
         "@leofcoin/utils": "^1.1.43",
         "@vandeurenglenn/base32": "^1.2.4",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leofcoin/chain",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Official javascript implementation",
   "private": false,
   "exports": {
@@ -67,11 +67,11 @@
     "@leofcoin/contracts": "^0.1.20",
     "@leofcoin/crypto": "^0.2.40",
     "@leofcoin/errors": "^1.0.29",
-    "@leofcoin/lib": "^1.3.0",
+    "@leofcoin/lib": "^1.3.1",
     "@leofcoin/messages": "^1.6.0",
     "@leofcoin/multi-wallet": "^3.1.9",
     "@leofcoin/networks": "^1.1.29",
-    "@leofcoin/peernet": "^1.2.22",
+    "@leofcoin/peernet": "^1.2.23",
     "@leofcoin/storage": "^3.5.38",
     "@leofcoin/utils": "^1.1.43",
     "@leofcoin/workers": "^1.5.31",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leofcoin/lib",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "type": "module",
   "typings": "./exports/typings/index.d.ts",
@@ -41,7 +41,7 @@
   "dependencies": {
     "@leofcoin/addresses": "^1.0.59",
     "@leofcoin/messages": "^1.5.3",
-    "@leofcoin/peernet": "^1.2.22",
+    "@leofcoin/peernet": "^1.2.23",
     "@leofcoin/storage": "^3.5.38",
     "@leofcoin/utils": "^1.1.43",
     "@vandeurenglenn/base32": "^1.2.4",


### PR DESCRIPTION
## Summary
- bump `@leofcoin/peernet` to 1.2.23 so transactions are signed by the selected account
- resolve `@netpeer/swarm` 0.9.10 and `socket-request-server` 1.7.4 for isolated concurrent peer routing
- bump `@leofcoin/lib` to 1.3.1 and `@leofcoin/chain` to 1.10.1

## Verification
- `npm test` (21 passing)
- `node --test test/e2e/*.test.js` (four isolated nodes converge and survive restart)