### PR TITLE
Pin npm for deterministic releases

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -30,6 +30,7 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
 
+      - run: npm install --global npm@11.13.0
       - run: npm ci
       - run: npm run release:prepare
 
@@ -69,6 +70,7 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
 
+      - run: npm install --global npm@11.13.0
       - run: npm ci
       - run: npm run release:publish
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "monorepo",
   "version": "1.0.1",
+  "packageManager": "npm@11.13.0",
   "description": "",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- declare npm 11.13.0 as the repository package manager
- install that exact npm version in prepare and publish jobs
- prevent npm 10/11 lockfile metadata churn

## Verification
- regenerated the lockfile with npm 11.13.0: no lockfile diff
- `git diff --check`

PR #100 will be regenerated after this merges.