### PR TITLE
Use npm trusted publishing

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   pull-requests: write
 
 jobs:
@@ -73,5 +74,3 @@ jobs:
       - run: npm install --global npm@11.13.0
       - run: npm ci
       - run: npm run release:publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -39,7 +39,8 @@ Publishing refuses to run from another branch or a dirty working tree. It builds
 and tests the repository, then publishes local package versions that are newer
 than npm. Workspace dependencies are published before their dependants.
 
-An npm login or an `NPM_TOKEN` with publish access is required.
+Publishing uses npm Trusted Publishing with GitHub Actions OIDC. It does not
+use a long-lived npm publish token.
 
 ## GitHub Actions
 
@@ -51,5 +52,26 @@ The **Release packages** workflow exposes the same process through
 2. Merge that pull request after CI succeeds.
 3. Run it with `publish` to build, test, and publish the merged versions.
 
-Add an npm automation token as the repository secret `NPM_TOKEN` before using
-the publish action.
+Before publishing a package for the first time, configure its npm Trusted
+Publisher with:
+
+- Provider: GitHub Actions
+- Organization or user: `leofcoin`
+- Repository: `monorepo`
+- Workflow filename: `release-packages.yml`
+- Allowed action: `npm publish`
+
+Every public workspace package must be configured once. The workflow requests
+GitHub's `id-token: write` permission, npm exchanges that identity for a
+short-lived credential, and npm attaches provenance to public packages
+automatically.
+
+With an interactive npm login that owns all workspace packages, configure them
+in one pass:
+
+```sh
+npm run release:trust
+```
+
+This invokes npm's official `npm trust github` command for every public
+workspace. It does not publish packages.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "release:status": "node scripts/release-packages.js status",
     "release:prepare": "node scripts/release-packages.js prepare",
     "release:publish": "node scripts/release-packages.js publish",
+    "release:trust": "node scripts/release-packages.js trust",
     "release:dry-run": "node scripts/release-packages.js prepare --dry-run",
     "patch": "npm run release:prepare",
     "release": "npm run release:publish",

--- a/scripts/release-packages.js
+++ b/scripts/release-packages.js
@@ -334,11 +334,33 @@ const publish = () => {
   }
 }
 
+const trust = () => {
+  for (const workspace of workspaces) {
+    console.log(`\nConfiguring trusted publishing for ${workspace.manifest.name}...`)
+    run(
+      'npm',
+      [
+        'trust',
+        'github',
+        workspace.manifest.name,
+        '--repo',
+        'leofcoin/monorepo',
+        '--file',
+        'release-packages.yml',
+        '--yes',
+      ],
+      { stdio: 'inherit' },
+    )
+  }
+}
+
 try {
   if (command === 'status') print(inspect())
   else if (command === 'prepare') prepare()
   else if (command === 'publish') publish()
-  else throw new Error(`Unknown command "${command}". Use status, prepare, or publish.`)
+  else if (command === 'trust') trust()
+  else
+    throw new Error(`Unknown command "${command}". Use status, prepare, publish, or trust.`)
 } catch (error) {
   console.error(`release-packages: ${error.message}`)
   process.exitCode = 1


### PR DESCRIPTION
## Summary
- replace long-lived publish-token authentication with GitHub OIDC
- grant the release workflow `id-token: write`
- remove `NODE_AUTH_TOKEN` from the publish step
- add `npm run release:trust` to configure every public workspace through the official npm trust CLI
- document the one-time trusted publisher setup

## Verification
- npm trusted-publisher registration dry-run for `@leofcoin/codecs` succeeded
- `node --check scripts/release-packages.js`
- `git diff --check`

No package was published by the failed token-based run.