### PR TITLE
Send npm trust publish permissions

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -31,7 +31,7 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
 
-      - run: npm install --global npm@11.13.0
+      - run: npm install --global npm@11.17.0
       - run: npm ci
       - run: npm run release:prepare
 
@@ -71,6 +71,6 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
 
-      - run: npm install --global npm@11.13.0
+      - run: npm install --global npm@11.17.0
       - run: npm ci
       - run: npm run release:publish

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monorepo",
   "version": "1.0.1",
-  "packageManager": "npm@11.13.0",
+  "packageManager": "npm@11.17.0",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/scripts/release-packages.js
+++ b/scripts/release-packages.js
@@ -347,6 +347,7 @@ const trust = () => {
         'leofcoin/monorepo',
         '--file',
         'release-packages.yml',
+        '--allow-publish',
         '--yes',
       ],
       { stdio: 'inherit' },


### PR DESCRIPTION
## Summary
- upgrade the pinned npm CLI from 11.13.0 to 11.17.0
- explicitly grant `publish` in npm trusted-publisher registrations
- use the same CLI version in prepare and publish jobs

## Root cause
The npm trust API now requires an allowed action. npm 11.13 did not expose `--allow-publish`, sent an empty permissions array, and the registry returned HTTP 400.

## Verification
- npm 11.17 trusted-publisher dry-run succeeds
- payload reports `permissions: publish`
- syntax and whitespace checks pass

No package or trust configuration was changed by the failed attempt.