### PR TITLE
Add package provenance repository metadata

### DIFF
--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -28,5 +28,9 @@
   "devDependencies": {
     "@rollup/plugin-json": "^6.1.0",
     "rollup": "^4.62.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
   }
 }

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -79,5 +79,9 @@
     "@vandeurenglenn/easy-worker": "^1.0.3",
     "@vandeurenglenn/typed-array-utils": "^1.2.0",
     "semver": "^7.8.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
   }
 }

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -35,5 +35,9 @@
     "rollup": "^4.62.3",
     "tslib": "^2.8.1",
     "typescript": "npm:@typescript/typescript6@^6.0.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
   }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/leofcoin/contracts.git"
+    "url": "https://github.com/leofcoin/monorepo"
   },
   "keywords": [],
   "author": "",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -28,5 +28,9 @@
     "decrypt"
   ],
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
+  }
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -24,5 +24,9 @@
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.3.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
   }
 }

--- a/packages/globals/package.json
+++ b/packages/globals/package.json
@@ -13,5 +13,9 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
+  }
 }

--- a/packages/just-a-doc/package.json
+++ b/packages/just-a-doc/package.json
@@ -26,5 +26,9 @@
   },
   "dependencies": {
     "globby": "^16.2.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -53,5 +53,9 @@
     "@rollup/plugin-typescript": "^12.3.0",
     "rollup": "^4.62.3",
     "tslib": "^2.8.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
   }
 }

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -272,5 +272,9 @@
     "@leofcoin/utils": "^1.1.43",
     "@vandeurenglenn/typed-array-smart-concat": "^1.0.4",
     "@vandeurenglenn/typed-array-smart-deconcat": "^1.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
   }
 }

--- a/packages/mnemonic/package.json
+++ b/packages/mnemonic/package.json
@@ -25,5 +25,9 @@
   },
   "dependencies": {
     "@leofcoin/crypto": "^0.2.40"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
   }
 }

--- a/packages/networks/package.json
+++ b/packages/networks/package.json
@@ -24,5 +24,9 @@
   "license": "MIT",
   "devDependencies": {
     "rollup": "^4.62.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -21,5 +21,9 @@
   "types": "./index.d.ts",
   "devDependencies": {
     "@vandeurenglenn/base58": "^1.1.9"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,5 +34,9 @@
   },
   "dependencies": {
     "@vandeurenglenn/proto-array": "^1.1.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
   }
 }

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -22,5 +22,9 @@
     "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
   }
 }

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -33,5 +33,9 @@
     "@leofcoin/storage": "^3.5.38",
     "@leofcoin/utils": "^1.1.43",
     "@vandeurenglenn/easy-worker": "^1.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leofcoin/monorepo"
   }
 }


### PR DESCRIPTION
## Summary
- add the exact monorepo repository URL to all 16 public workspace manifests
- normalize existing string repository fields to npm repository objects
- satisfy npm OIDC provenance validation

## Root cause
Trusted publishing authenticated correctly and signed provenance, but npm rejected the first upload because `package.json.repository.url` was empty instead of matching `https://github.com/leofcoin/monorepo`.

## Verification
- all public workspace manifests report the exact trusted repository URL
- lockfile regeneration produces no diff
- `git diff --check`
- registry still has none of the target releases

All 16 npm trusted-publisher relationships are already configured with publish permission.