### PR TITLE
Upgrade GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -21,11 +21,11 @@ jobs:
     if: inputs.action == 'prepare'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22.x
           cache: npm
@@ -61,11 +61,11 @@ jobs:
     if: inputs.action == 'publish'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22.x
           cache: npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
         node-version: [22.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'


### PR DESCRIPTION
## Summary
- upgrade all `actions/checkout` usages from v4 to v7
- upgrade all `actions/setup-node` usages from v4 to v7
- remove the deprecated internal Node 20 action runtime warning
- pick up setup-node v7 removal of the dummy `NODE_AUTH_TOKEN`, eliminating the misleading npm token notice

## Verification
- audited every workflow action reference
- all six checkout/setup-node calls now use v7
- no v4 references remain
- `git diff --check`

Application Node tests remain on Node 22; only the actions implementation runtime moves to Node 24.