### PR TITLE
Use peernet 1.2.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1435,9 +1435,9 @@
       "link": true
     },
     "node_modules/@leofcoin/peernet": {
-      "version": "1.2.23",
-      "resolved": "https://registry.npmjs.org/@leofcoin/peernet/-/peernet-1.2.23.tgz",
-      "integrity": "sha512-8vwy0eaScroaYHC2ei4UpW77kZiSDWvT5XSvmm5Q5/jeMq16ovebGf1A3ElSk2kS8hMjH1BGb1d2z1mI5uuNUA==",
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@leofcoin/peernet/-/peernet-1.2.24.tgz",
+      "integrity": "sha512-/JZsfhdp/7di3YSCF1Gtf25wCEk6ZivWurq1Z1FZxZlnZJvTN2ldjMcYl1nlXSnRWXdlAiKj4qPSsPusb+QXbA==",
       "license": "MIT",
       "dependencies": {
         "@leofcoin/codec-format-interface": "^1.8.2",
@@ -9250,7 +9250,7 @@
     },
     "packages/chain": {
       "name": "@leofcoin/chain",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
         "@leofcoin/addresses": "^1.0.59",
@@ -9262,7 +9262,7 @@
         "@leofcoin/messages": "^1.6.0",
         "@leofcoin/multi-wallet": "^3.1.9",
         "@leofcoin/networks": "^1.1.29",
-        "@leofcoin/peernet": "^1.2.23",
+        "@leofcoin/peernet": "^1.2.24",
         "@leofcoin/storage": "^3.5.38",
         "@leofcoin/utils": "^1.1.43",
         "@leofcoin/workers": "^1.5.31",
@@ -9419,12 +9419,12 @@
     },
     "packages/lib": {
       "name": "@leofcoin/lib",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@leofcoin/addresses": "^1.0.59",
         "@leofcoin/messages": "^1.5.3",
-        "@leofcoin/peernet": "^1.2.23",
+        "@leofcoin/peernet": "^1.2.24",
         "@leofcoin/storage": "^3.5.38",
         "@leofcoin/utils": "^1.1.43",
         "@vandeurenglenn/base32": "^1.2.4",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leofcoin/chain",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Official javascript implementation",
   "private": false,
   "exports": {
@@ -71,7 +71,7 @@
     "@leofcoin/messages": "^1.6.0",
     "@leofcoin/multi-wallet": "^3.1.9",
     "@leofcoin/networks": "^1.1.29",
-    "@leofcoin/peernet": "^1.2.23",
+    "@leofcoin/peernet": "^1.2.24",
     "@leofcoin/storage": "^3.5.38",
     "@leofcoin/utils": "^1.1.43",
     "@leofcoin/workers": "^1.5.31",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leofcoin/lib",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "",
   "type": "module",
   "typings": "./exports/typings/index.d.ts",
@@ -41,7 +41,7 @@
   "dependencies": {
     "@leofcoin/addresses": "^1.0.59",
     "@leofcoin/messages": "^1.5.3",
-    "@leofcoin/peernet": "^1.2.23",
+    "@leofcoin/peernet": "^1.2.24",
     "@leofcoin/storage": "^3.5.38",
     "@leofcoin/utils": "^1.1.43",
     "@vandeurenglenn/base32": "^1.2.4",


### PR DESCRIPTION
Updates chain and lib to the released peernet version that preserves both current and legacy identity account derivation. Patch versions were prepared by the repository release tool.\n\nValidation:\n- npm test: 21/21 passing\n- installed @leofcoin/peernet version: 1.2.24\n- transaction sender/signature binding tests pass