### PR TITLE
Declare ethers as a utils runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/runtime": {
@@ -1670,7 +1669,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.3.2"
@@ -1683,7 +1681,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -2950,7 +2947,6 @@
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/agent-base": {
@@ -4216,7 +4212,6 @@
       "version": "6.17.0",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.17.0.tgz",
       "integrity": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -4245,7 +4240,6 @@
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -4255,14 +4249,12 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/ethers/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/event-emitter": {
@@ -9290,7 +9282,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -9600,14 +9591,14 @@
     },
     "packages/utils": {
       "name": "@leofcoin/utils",
-      "version": "1.1.44",
+      "version": "1.1.45",
       "license": "MIT",
       "dependencies": {
-        "@vandeurenglenn/proto-array": "^1.1.0"
+        "@vandeurenglenn/proto-array": "^1.1.0",
+        "ethers": "^6.17.0"
       },
       "devDependencies": {
         "@typescript/native": "npm:typescript@^7.0.2",
-        "ethers": "^6.17.0",
         "typescript": "npm:@typescript/typescript6@^6.0.2"
       }
     },
@@ -9627,7 +9618,7 @@
     },
     "packages/workers": {
       "name": "@leofcoin/workers",
-      "version": "1.5.33",
+      "version": "1.5.34",
       "license": "MIT",
       "dependencies": {
         "@leofcoin/addresses": "^1.0.59",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leofcoin/utils",
-  "version": "1.1.44",
+  "version": "1.1.45",
   "description": "",
   "type": "module",
   "browser": "./exports/browser/utils.js",
@@ -29,11 +29,11 @@
   "license": "MIT",
   "devDependencies": {
     "@typescript/native": "npm:typescript@^7.0.2",
-    "ethers": "^6.17.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2"
   },
   "dependencies": {
-    "@vandeurenglenn/proto-array": "^1.1.0"
+    "@vandeurenglenn/proto-array": "^1.1.0",
+    "ethers": "^6.17.0"
   },
   "repository": {
     "type": "git",

--- a/packages/utils/test/package.test.js
+++ b/packages/utils/test/package.test.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+test('declares ethers as a runtime dependency', async () => {
+  const manifest = JSON.parse(
+    await readFile(new URL('../package.json', import.meta.url), 'utf8')
+  )
+
+  assert.equal(manifest.dependencies.ethers, '^6.17.0')
+  assert.equal(manifest.devDependencies.ethers, undefined)
+})

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leofcoin/workers",
-  "version": "1.5.33",
+  "version": "1.5.34",
   "description": "Workers used in @leofcoin/chain",
   "type": "module",
   "private": false,


### PR DESCRIPTION
Moves ethers from devDependencies to dependencies in @leofcoin/utils so clean consumers can load its runtime exports. The release tool prepares utils 1.1.45 and workers 1.5.34 (workers also had pending manifest changes since its published gitHead).\n\nValidation:\n- utils build and manifest regression test pass\n- packed utils installed into an empty consumer directory\n- isolated import and parseUnits execution succeed\n- 21/21 core tests pass