### PR TITLE
Wait for machine worker readiness

### DIFF
--- a/packages/chain/src/machine.ts
+++ b/packages/chain/src/machine.ts
@@ -92,6 +92,7 @@ export default class Machine {
         break
       }
       case 'machine-ready': {
+        this.readyResolve(this)
         pubsub.publish('machine.ready', true)
         break
       }
@@ -316,7 +317,6 @@ export default class Machine {
         }
       }
       this.worker.postMessage(message)
-      this.readyResolve(this)
     })
   }
 

--- a/packages/chain/test/operational.test.js
+++ b/packages/chain/test/operational.test.js
@@ -120,6 +120,7 @@ test('isolated offline nodes initialize their chain state', async () => {
     )
     for (const { stdout, stderr } of results) {
       assert.match(stdout, /CHAIN_READY/)
+      assert.match(stdout, /MACHINE_READY/)
       assert.match(stdout, /chain: 'loaded'/)
       assert.doesNotMatch(stderr, /TypeError|CHAIN_READY_TIMEOUT/)
     }

--- a/packages/chain/test/runtime-smoke.js
+++ b/packages/chain/test/runtime-smoke.js
@@ -1,4 +1,5 @@
 const root = `.leofcoin-smoke-${process.pid}`
+const { default: addresses } = await import('@leofcoin/addresses')
 const { default: Node } = await import('../exports/node.js')
 const node = new Node(
   {
@@ -22,5 +23,8 @@ const timeout = setTimeout(() => {
 
 await chain.ready
 clearTimeout(timeout)
+const validators = await chain.staticCall(addresses.validators, 'validators')
+if (!Array.isArray(validators)) throw new Error('validators contract was not ready with chain.ready')
+console.log('MACHINE_READY', validators.length)
 console.log('CHAIN_READY', chain.state, await chain.lastBlock)
 process.exit(0)


### PR DESCRIPTION
Fixes chain.ready resolving before the machine worker has actually restored contracts. Machine.ready now resolves only after the worker emits machine-ready, preventing participate() from racing validators.has and timing out.\n\nAdds an operational regression assertion that the validators contract can be queried immediately after chain.ready. Two isolated runtime smoke nodes and all focused operational tests pass.\n\nThe WebTransport urlTemplate warning is non-fatal and separate; the shown peer successfully falls back and connects.