### PR TITLE
Reset complete state when creating genesis

### DIFF
--- a/packages/chain/src/state.ts
+++ b/packages/chain/src/state.ts
@@ -331,18 +331,22 @@ export default class State extends Contract {
   }
 
   async getAndPutBlock(hash: string): Promise<BlockMessage> {
-    // todo peernet resolves undefined blocks....
     let block = await globalThis.peernet.get(hash, 'block')
-    if (block !== undefined) {
-      if (!(block instanceof Uint8Array)) {
-        block = new Uint8Array(Object.values(block))
-      }
-      block = await new BlockMessage(block)
-
-      const { index } = block.decoded
-      if (this.#blocks[index] && this.#blocks[index].hash !== block.hash) throw `invalid block ${hash} @${index}`
-      if (!(await globalThis.peernet.has(hash))) await globalThis.peernet.put(hash, block.encoded, 'block')
+    if (block === undefined || block === null) {
+      throw new ResolveError(`block data unavailable for ${hash}`)
     }
+
+    if (!(block instanceof Uint8Array)) block = new Uint8Array(Object.values(block))
+    block = await new BlockMessage(block)
+
+    const resolvedHash = await block.hash()
+    if (resolvedHash !== hash) throw new ResolveError(`block hash mismatch: requested ${hash}, received ${resolvedHash}`)
+
+    const { index } = block.decoded
+    if (this.#blocks[index] && this.#blocks[index].hash !== resolvedHash) {
+      throw new ResolveError(`conflicting block ${resolvedHash} @${index}`)
+    }
+    if (!(await globalThis.peernet.has(hash))) await globalThis.peernet.put(hash, block.encoded, 'block')
     return block
   }
 

--- a/packages/chain/test/unit/genesis-state.test.js
+++ b/packages/chain/test/unit/genesis-state.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { clearGenesisState, genesisStateStores } from '../../../../scripts/genesis-state.js'
+
+test('genesis reset clears every persisted chain-state store', async () => {
+  const cleared = []
+  const stores = Object.fromEntries(
+    genesisStateStores.map((name) => [name, { clear: async () => cleared.push(name) }])
+  )
+
+  await clearGenesisState(stores)
+
+  assert.deepEqual(cleared.sort(), [...genesisStateStores].sort())
+  assert.ok(cleared.includes('chainStore'))
+  assert.ok(cleared.includes('stateStore'))
+})
+
+test('genesis reset fails closed when a required store is unavailable', async () => {
+  await assert.rejects(clearGenesisState({}), /genesis state store is unavailable: blockStore/)
+})

--- a/scripts/create-genesis.js
+++ b/scripts/create-genesis.js
@@ -1,5 +1,6 @@
 import { writeFile as write, readFile as read } from 'fs/promises'
 import { join } from 'path'
+import { clearGenesisState } from './genesis-state.js'
 ;(async () => {
   const { parseUnits } = await import('@leofcoin/utils')
   const { nodeConfig, createContractMessage } = await import('@leofcoin/lib')
@@ -42,11 +43,7 @@ import { join } from 'path'
     console.log(`Identity loaded successfully: ${globalThis.peernet.selectedAccount}`)
     return
   }
-  await globalThis.blockStore.clear()
-  await globalThis.transactionPoolStore.clear()
-  await globalThis.contractStore.clear()
-  await globalThis.transactionStore.clear()
-  await globalThis.accountsStore.clear()
+  await clearGenesisState()
   console.log(node)
   // console.log(peernet);
   // const chain = await new Chain()

--- a/scripts/genesis-state.js
+++ b/scripts/genesis-state.js
@@ -1,0 +1,21 @@
+export const genesisStateStores = [
+  'blockStore',
+  'chainStore',
+  'stateStore',
+  'transactionPoolStore',
+  'contractStore',
+  'transactionStore',
+  'accountsStore'
+]
+
+export const clearGenesisState = async (stores = globalThis) => {
+  await Promise.all(
+    genesisStateStores.map((name) => {
+      const store = stores[name]
+      if (!store || typeof store.clear !== 'function') {
+        throw new Error(`genesis state store is unavailable: ${name}`)
+      }
+      return store.clear()
+    })
+  )
+}


### PR DESCRIPTION
Fixes create-genesis leaving stale chainStore.lastBlock and stateStore snapshots behind after clearing blockStore. Genesis now clears every persisted chain-state store, including chain and state, while freshIdentity handles wallet replacement.\n\nBlock fetching now also fails explicitly for unavailable data, verifies the content hash matches the requested hash, and rejects index conflicts instead of dereferencing undefined.\n\nValidation: chain build passes; 23/23 tests pass (5 messages + 18 chain), including complete-reset and fail-closed regressions.