### PR TITLE
Use current nonce for bootstrap transactions

### DIFF
--- a/packages/chain/test/chain.js
+++ b/packages/chain/test/chain.js
@@ -84,7 +84,7 @@ if (Object.keys(await chain.balances).length === 0 && !hasTransactionsInPool) {
     {
       from: peernet.selectedAccount,
       to: chain.nativeToken,
-      nonce: 2,
+      nonce: nonce + 2,
       priority: true,
       method: 'mint',
       params: [peernet.selectedAccount, parseUnits('100000000000000')]
@@ -93,7 +93,7 @@ if (Object.keys(await chain.balances).length === 0 && !hasTransactionsInPool) {
       from: peernet.selectedAccount,
       to: chain.nativeToken,
       method: 'grantRole',
-      nonce: 1,
+      nonce: nonce + 1,
       priority: true,
       params: [peernet.selectedAccount, 'MINT']
     }


### PR DESCRIPTION
Updates the manual chain bootstrap test to allocate grantRole and mint nonces relative to the account's current committed nonce. Validator participation already consumes nonces, so hardcoded 1 and 2 were correctly rejected as replays. Duplicate nonce validation remains unchanged.\n\nValidation: syntax check and 23/23 core tests pass. Generated addresses and bytecodes remain uncommitted.