### PR TITLE
Fix block production retry loop

### DIFF
--- a/packages/chain/src/chain.ts
+++ b/packages/chain/src/chain.ts
@@ -29,6 +29,8 @@ import ConnectionMonitor from './connection-monitor.js'
 import { quorumThreshold } from './consensus/quorum.js'
 import { validateChainLink } from './consensus/chain-link.js'
 import { signConsensusMessage, verifyConsensusMessage } from './consensus/signature.js'
+import { nextBlockIndex, proposalDelay } from './consensus/cadence.js'
+import { compareTransactionNonces, pruneCanonicalTransactions } from './consensus/transaction-pool.js'
 
 const debug = createDebugger('leofcoin/chain')
 
@@ -38,6 +40,8 @@ export default class Chain extends VersionControl {
 
   #slotTime = 10000
   #blockTime = 6000 // 6 second target block time
+  /** Wall-clock time of the last local proposal attempt. */
+  #lastProposalAt = 0
   #epochLength = 10 // Blocks per epoch (enables block-based epoch boundaries)
   id
   utils = {}
@@ -286,9 +290,7 @@ export default class Chain extends VersionControl {
   async #runEpoch(): Promise<void> {
     if (this.#runningEpoch) return
     this.#runningEpoch = true
-    console.log('epoch')
     const validators = await this.#getConsensusValidators()
-    console.log({ validators })
 
     if (this.#isJailed(peernet.selectedAccount)) {
       this.#runningEpoch = false
@@ -300,10 +302,25 @@ export default class Chain extends VersionControl {
       return
     }
 
+    // Apply cadence before every attempt. The canonical timestamp prevents a
+    // newly triggered epoch from proposing too soon after the previous block;
+    // the local timestamp also throttles empty/failed proposal attempts.
+    let localBlock = await this.lastBlock
+    const delay = proposalDelay({
+      now: Date.now(),
+      lastBlockTimestamp: Number(localBlock?.timestamp ?? 0),
+      lastProposalAt: this.#lastProposalAt,
+      blockTime: this.#blockTime
+    })
+    if (delay > 0) await this.#sleep(delay)
+
+    // Re-read the canonical tip after waiting: a peer may have committed the
+    // next height and changed the deterministic proposer in the meantime.
+    localBlock = await this.lastBlock
+
     // Phase 1: Deterministic proposer selection
     // proposer = validators[(nextBlockIndex + round) % validators.length]
-    const localBlock = await this.lastBlock
-    const nextIndex = (localBlock?.index !== undefined ? Number(localBlock.index) : -1) + 1
+    const nextIndex = nextBlockIndex(localBlock?.index)
     const proposerIdx = (nextIndex + this.#consensusRound) % validators.length
     const isProposer = validators[proposerIdx] === peernet.selectedAccount
 
@@ -328,7 +345,7 @@ export default class Chain extends VersionControl {
       this.#roundTimer = null
     }
 
-    const start = Date.now()
+    this.#lastProposalAt = Date.now()
 
     try {
       await this.#createBlock()
@@ -336,15 +353,7 @@ export default class Chain extends VersionControl {
       console.error(error)
     }
 
-    const end = Date.now()
-    console.log((end - start) / 1000 + ' s')
-
-    // enforce target block time to avoid tight loops
-    const elapsed = end - start
-    const remaining = this.#blockTime - elapsed
     const hasMore = await this.hasTransactionToHandle()
-    // Only delay if there's no backlog; if backlog exists, continue immediately
-    if (!hasMore && remaining > 0) await this.#sleep(remaining)
 
     this.#runningEpoch = false
     if (hasMore && !this.#proposalInFlight) return this.#runEpoch()
@@ -903,6 +912,10 @@ export default class Chain extends VersionControl {
   }
 
   async #peerConnected(peerId) {
+    if (typeof peerId !== 'string' || !peerId.trim() || peerId === 'undefined') {
+      debug('ignored peer connection without a valid peer id')
+      return
+    }
     debug(`peer connected: ${peerId}`)
     const peer = peernet.getConnection(peerId)
 
@@ -1172,7 +1185,7 @@ export default class Chain extends VersionControl {
         return (b.decoded.priority ? 1 : 0) - (a.decoded.priority ? 1 : 0)
       }
       // Secondary: by nonce
-      const nonceDiff = (a.decoded?.nonce ?? 0) - (b.decoded?.nonce ?? 0)
+      const nonceDiff = compareTransactionNonces(a.decoded?.nonce, b.decoded?.nonce)
       if (nonceDiff !== 0) return nonceDiff
       // Tertiary: in stable order (insertion order preserved)
       return 0
@@ -1314,7 +1327,6 @@ export default class Chain extends VersionControl {
   // todo filter tx that need to wait on prev nonce
   async #createBlock(limit = this.transactionLimit) {
     if (this.#proposalInFlight) return
-    console.log(await globalThis.transactionPoolStore.size())
 
     // vote for transactions
     if ((await globalThis.transactionPoolStore.size()) === 0) return
@@ -1343,14 +1355,24 @@ export default class Chain extends VersionControl {
     // exclude failing tx
     transactions = await this.promiseTransactions(transactions)
 
+    // A transaction that already exists in canonical state is not pending.
+    // Prune it before signature validation so stale pools cannot repeatedly
+    // decode and validate the same transactions forever.
+    const pendingTransactions = await pruneCanonicalTransactions(
+      transactions,
+      latestTransactions,
+      (hash) => globalThis.transactionStore.has(hash),
+      (hash) => globalThis.transactionPoolStore.delete(hash)
+    )
+
     // Combine priority and normal transactions, then sort deterministically
-    const allTransactions = transactions.sort((a, b) => {
+    const allTransactions = pendingTransactions.sort((a, b) => {
       // Primary: by priority (true first)
-      if (a.decoded.priority !== b.decoded.priority) {
-        return (b.decoded.priority ? 1 : 0) - (a.decoded.priority ? 1 : 0)
+      if (a.transaction.decoded.priority !== b.transaction.decoded.priority) {
+        return (b.transaction.decoded.priority ? 1 : 0) - (a.transaction.decoded.priority ? 1 : 0)
       }
       // Secondary: by nonce
-      const nonceDiff = (a.decoded?.nonce ?? 0) - (b.decoded?.nonce ?? 0)
+      const nonceDiff = compareTransactionNonces(a.transaction.decoded?.nonce, b.transaction.decoded?.nonce)
       if (nonceDiff !== 0) return nonceDiff
       // Tertiary: in stable order (insertion order preserved)
       return 0
@@ -1358,12 +1380,8 @@ export default class Chain extends VersionControl {
 
     // A proposal only validates and publishes transaction data. Canonical
     // execution happens in #addBlock after quorum is reached.
-    for (const transaction of allTransactions) {
+    for (const { transaction, hash } of allTransactions) {
       await this.validateTransactionSignature(transaction)
-      const hash = await transaction.hash()
-      if (latestTransactions.includes(hash) || (await globalThis.transactionStore.has(hash))) {
-        continue
-      }
       block.transactions.push(hash)
       block.fees += BigInt(await calculateFee(transaction.decoded))
       await globalThis.peernet.put(hash, transaction.encoded, 'transaction')
@@ -1373,9 +1391,7 @@ export default class Chain extends VersionControl {
     if (block.transactions.length === 0) return
 
     const localBlock = await this.lastBlock
-    block.index = localBlock.index
-    if (block.index === undefined) block.index = 0
-    else block.index += 1
+    block.index = nextBlockIndex(localBlock?.index)
 
     block.previousHash = localBlock.hash || '0x0'
     // block.timestamp = Date.now()

--- a/packages/chain/src/consensus/cadence.ts
+++ b/packages/chain/src/consensus/cadence.ts
@@ -1,0 +1,25 @@
+export interface ProposalCadence {
+  now: number
+  lastBlockTimestamp?: number
+  lastProposalAt?: number
+  blockTime: number
+}
+
+/** Chain heights are represented as numbers internally, even when wire-decoded as bigint. */
+export const nextBlockIndex = (lastIndex: number | bigint | undefined): number => Number(lastIndex ?? -1) + 1
+
+/** Return the delay required before another local block proposal is allowed. */
+export const proposalDelay = ({
+  now,
+  lastBlockTimestamp = 0,
+  lastProposalAt = 0,
+  blockTime
+}: ProposalCadence): number => {
+  // A malformed future timestamp must not stall local block production beyond
+  // one normal interval.
+  const canonicalBase = Math.min(lastBlockTimestamp, now)
+  const nextFromCanonicalBlock = canonicalBase > 0 ? canonicalBase + blockTime : 0
+  const nextFromLocalAttempt = lastProposalAt > 0 ? lastProposalAt + blockTime : 0
+
+  return Math.max(0, Math.max(nextFromCanonicalBlock, nextFromLocalAttempt) - now)
+}

--- a/packages/chain/src/consensus/transaction-pool.ts
+++ b/packages/chain/src/consensus/transaction-pool.ts
@@ -1,0 +1,42 @@
+interface HashableTransaction {
+  hash(): Promise<string>
+}
+
+export interface PendingTransaction<T extends HashableTransaction> {
+  transaction: T
+  hash: string
+}
+
+/** Compare wire-decoded nonces without mixing number and bigint arithmetic. */
+export const compareTransactionNonces = (
+  left: number | bigint | string | undefined,
+  right: number | bigint | string | undefined
+): number => {
+  const leftNonce = BigInt(left ?? 0)
+  const rightNonce = BigInt(right ?? 0)
+  if (leftNonce < rightNonce) return -1
+  if (leftNonce > rightNonce) return 1
+  return 0
+}
+
+/** Remove transactions from the pending pool once they are already canonical. */
+export const pruneCanonicalTransactions = async <T extends HashableTransaction>(
+  transactions: T[],
+  latestTransactionHashes: Iterable<string>,
+  isStored: (hash: string) => Promise<boolean>,
+  removePending: (hash: string) => Promise<unknown>
+): Promise<PendingTransaction<T>[]> => {
+  const latest = new Set(latestTransactionHashes)
+  const pending: PendingTransaction<T>[] = []
+
+  for (const transaction of transactions) {
+    const hash = await transaction.hash()
+    if (latest.has(hash) || (await isStored(hash))) {
+      await removePending(hash)
+      continue
+    }
+    pending.push({ transaction, hash })
+  }
+
+  return pending
+}

--- a/packages/chain/test/unit/cadence.test.js
+++ b/packages/chain/test/unit/cadence.test.js
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { nextBlockIndex, proposalDelay } from '../../src/consensus/cadence.ts'
+
+test('derives the same numeric next height from number and bigint indexes', () => {
+  assert.equal(nextBlockIndex(undefined), 0)
+  assert.equal(nextBlockIndex(41), 42)
+  assert.equal(nextBlockIndex(41n), 42)
+})
+
+test('paces proposals from the last canonical block during transaction backlog', () => {
+  assert.equal(
+    proposalDelay({ now: 10_001, lastBlockTimestamp: 10_000, lastProposalAt: 0, blockTime: 6_000 }),
+    5_999
+  )
+})
+
+test('paces repeated attempts even when no new block was committed', () => {
+  assert.equal(
+    proposalDelay({ now: 15_000, lastBlockTimestamp: 1_000, lastProposalAt: 12_000, blockTime: 6_000 }),
+    3_000
+  )
+})
+
+test('allows a proposal once both canonical and local cadence have elapsed', () => {
+  assert.equal(
+    proposalDelay({ now: 20_000, lastBlockTimestamp: 10_000, lastProposalAt: 12_000, blockTime: 6_000 }),
+    0
+  )
+})
+
+test('does not let a future canonical timestamp stall production indefinitely', () => {
+  assert.equal(
+    proposalDelay({ now: 20_000, lastBlockTimestamp: 200_000, lastProposalAt: 0, blockTime: 6_000 }),
+    6_000
+  )
+})

--- a/packages/chain/test/unit/transaction-pool.test.js
+++ b/packages/chain/test/unit/transaction-pool.test.js
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { compareTransactionNonces, pruneCanonicalTransactions } from '../../src/consensus/transaction-pool.ts'
+
+const transaction = (hash) => ({ hash: async () => hash })
+
+test('removes recent and persisted canonical transactions from the pending pool', async () => {
+  const removed = []
+  const pending = await pruneCanonicalTransactions(
+    [transaction('recent'), transaction('stored'), transaction('pending')],
+    ['recent'],
+    async (hash) => hash === 'stored',
+    async (hash) => removed.push(hash)
+  )
+
+  assert.deepEqual(removed, ['recent', 'stored'])
+  assert.deepEqual(
+    pending.map(({ hash }) => hash),
+    ['pending']
+  )
+})
+
+test('orders number, bigint, and encoded string nonces without mixing arithmetic types', () => {
+  const nonces = [4n, 2, '3', 1n]
+  nonces.sort(compareTransactionNonces)
+  assert.deepEqual(nonces, [1n, 2, '3', 4n])
+})


### PR DESCRIPTION
## What changed

- enforce the six-second proposal cadence even while transactions are backlogged
- throttle empty and failed local proposal attempts
- re-read the canonical tip after waiting before selecting the proposer
- prune already-canonical transactions from the pending pool
- compare mixed number/bigint/string nonces deterministically
- normalize wire-decoded block indexes before incrementing them
- ignore peer connection events without a valid peer id

## Root causes

The backlog path skipped the block delay entirely, allowing a single validator to loop at CPU speed. Canonical transactions could remain pending forever, causing the same signatures to be decoded repeatedly. Wire-decoded nonces and block indexes could also mix bigint and number arithmetic. Finally, malformed swarm announcements propagated an undefined peer id into the chain handshake.

## Validation

- full core build completed
- message tests: 5 passing
- chain tests: 25 passing
- `git diff --check`
- `release:status` detects chain plus the already-merged unpublished lib/messages/workers changes

Existing TypeScript warnings in contracts remain unchanged.

## Rollout

This changes validator scheduling behavior and should be deployed to validators together. After merge, the release workflow should patch every package reported by `release:status`: `@leofcoin/chain`, `@leofcoin/lib`, `@leofcoin/messages`, and `@leofcoin/workers`. The upstream malformed peer announcement is fixed separately in netpeer/swarm#4.