### PR TITLE
Bump peernet to 1.2.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1434,9 +1434,9 @@
       "link": true
     },
     "node_modules/@leofcoin/peernet": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/@leofcoin/peernet/-/peernet-1.2.26.tgz",
-      "integrity": "sha512-VawEywENuY1XqkKzze8VtE0M327pxW71rCfcwM90lmSkLK+wLkf4GD3QvmpoLQktHGzQiigpUGW+57CUfa/YGQ==",
+      "version": "1.2.27",
+      "resolved": "https://registry.npmjs.org/@leofcoin/peernet/-/peernet-1.2.27.tgz",
+      "integrity": "sha512-j3ojNOri6oxc3GkKWdXwaIM0vxPGN1qdV2xYmrF60jFgbKEbXbXK2hoY9Vhj9sNlMgxuUZES/AADJEg3PG1wWA==",
       "license": "MIT",
       "dependencies": {
         "@leofcoin/codec-format-interface": "^1.8.2",
@@ -1446,7 +1446,7 @@
         "@leofcoin/multi-wallet": "^3.1.8",
         "@leofcoin/storage": "^3.5.38",
         "@mapbox/node-pre-gyp": "^2.0.3",
-        "@netpeer/swarm": "^0.9.9",
+        "@netpeer/swarm": "^0.9.11",
         "@vandeurenglenn/base58": "^1.1.9",
         "@vandeurenglenn/debug": "^1.4.0",
         "@vandeurenglenn/little-pubsub": "^1.5.2",
@@ -1652,9 +1652,9 @@
       }
     },
     "node_modules/@netpeer/swarm": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@netpeer/swarm/-/swarm-0.9.10.tgz",
-      "integrity": "sha512-glrpdtQTdsp8/qE0SFaADlF605iuPfj+5N+yW/SK/BuWTi7ijpDQEVzfTTg7efwlVXMX39x45emBnUXBznrUug==",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@netpeer/swarm/-/swarm-0.9.11.tgz",
+      "integrity": "sha512-dGperBvwpKLAR0IS8/NGeTED081RSQVU12p27GPoBK2wmh+ymrzGB55Q5+eq6oPSJaRoqwvtm4EvgqsSksqLeg==",
       "license": "MIT",
       "dependencies": {
         "@koush/wrtc": "^0.5.3",
@@ -9391,7 +9391,7 @@
         "@leofcoin/messages": "^1.6.1",
         "@leofcoin/multi-wallet": "^3.1.9",
         "@leofcoin/networks": "^1.1.30",
-        "@leofcoin/peernet": "^1.2.26",
+        "@leofcoin/peernet": "^1.2.27",
         "@leofcoin/storage": "^3.5.38",
         "@leofcoin/utils": "^1.1.45",
         "@leofcoin/workers": "^1.5.34",
@@ -9525,7 +9525,7 @@
       "dependencies": {
         "@leofcoin/addresses": "^1.0.60",
         "@leofcoin/messages": "^1.6.1",
-        "@leofcoin/peernet": "^1.2.26",
+        "@leofcoin/peernet": "^1.2.27",
         "@leofcoin/storage": "^3.5.38",
         "@leofcoin/utils": "^1.1.45",
         "@vandeurenglenn/base32": "^1.2.4",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -71,7 +71,7 @@
     "@leofcoin/messages": "^1.6.1",
     "@leofcoin/multi-wallet": "^3.1.9",
     "@leofcoin/networks": "^1.1.30",
-    "@leofcoin/peernet": "^1.2.26",
+    "@leofcoin/peernet": "^1.2.27",
     "@leofcoin/storage": "^3.5.38",
     "@leofcoin/utils": "^1.1.45",
     "@leofcoin/workers": "^1.5.34",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@leofcoin/addresses": "^1.0.60",
     "@leofcoin/messages": "^1.6.1",
-    "@leofcoin/peernet": "^1.2.26",
+    "@leofcoin/peernet": "^1.2.27",
     "@leofcoin/storage": "^3.5.38",
     "@leofcoin/utils": "^1.1.45",
     "@vandeurenglenn/base32": "^1.2.4",


### PR DESCRIPTION
Rolls the normalized swarm peer announcements into the chain and lib workspaces via `@leofcoin/peernet@1.2.27`. The lockfile now resolves `@netpeer/swarm@0.9.11`.\n\nValidated with:\n- `npm run build:core`\n- `npm run test -w @leofcoin/lib` (1/1)\n- `npm run test -w @leofcoin/chain` (25/25)