### PR TITLE
Fix last block response decoding

### DIFF
--- a/packages/chain/src/chain.ts
+++ b/packages/chain/src/chain.ts
@@ -6,7 +6,6 @@ import {
   TransactionMessage,
   BlockMessage,
   BWMessage,
-  LastBlockMessage,
   StateMessage,
   PrevoteMessage,
   PrecommitMessage,
@@ -31,6 +30,7 @@ import { validateChainLink } from './consensus/chain-link.js'
 import { signConsensusMessage, verifyConsensusMessage } from './consensus/signature.js'
 import { nextBlockIndex, proposalDelay } from './consensus/cadence.js'
 import { compareTransactionNonces, pruneCanonicalTransactions } from './consensus/transaction-pool.js'
+import { resolveLastBlockMessage } from './helpers/last-block.js'
 
 const debug = createDebugger('leofcoin/chain')
 
@@ -768,48 +768,6 @@ export default class Chain extends VersionControl {
     }
   }
 
-  async #resolveLastBlockMessage(result: unknown) {
-    if (result instanceof Uint8Array) {
-      try {
-        // Unwrap nested peernet-response wrappers before attempting LastBlockMessage decode.
-        let payload: unknown = result
-        for (let i = 0; i < 3; i += 1) {
-          try {
-            const wrapped = await new globalThis.peernet.protos['peernet-response'](payload)
-            if (wrapped?.decoded?.response === undefined) break
-            payload = wrapped.decoded.response
-          } catch {
-            break
-          }
-        }
-        if (payload !== result) return this.#resolveLastBlockMessage(payload)
-
-        return new LastBlockMessage(result)
-      } catch {
-        const candidate = new TextDecoder().decode(result)
-        if (candidate) {
-          const blockData = await globalThis.peernet.get(candidate, 'block')
-          if (blockData) return new BlockMessage(blockData)
-        }
-      }
-    }
-
-    if (typeof result === 'string') {
-      const blockData = await globalThis.peernet.get(result, 'block')
-      if (blockData) return new BlockMessage(blockData)
-    }
-
-    if (result && typeof result === 'object') {
-      const response = (result as any).decoded?.response ?? (result as any).response
-      if (response !== undefined) return this.#resolveLastBlockMessage(response)
-      if ('hash' in result && 'index' in result) {
-        return new LastBlockMessage(result)
-      }
-    }
-
-    throw new Error(`invalid lastBlock payload: ${typeof result}`)
-  }
-
   async #decodeKnownBlocksResponse(response: any): Promise<{ blocks: string[] } | null> {
     if (!response) return null
 
@@ -971,7 +929,7 @@ export default class Chain extends VersionControl {
       if (lastBlockRaw === undefined || lastBlockRaw === null) {
         throw new Error(`invalid lastBlock payload: ${typeof lastBlockRaw}`)
       }
-      const lastBlockMessage = await this.#resolveLastBlockMessage(lastBlockRaw)
+      const lastBlockMessage = await resolveLastBlockMessage(lastBlockRaw)
       console.log(lastBlockMessage)
       lastBlock = lastBlockMessage.decoded
     } catch (error) {

--- a/packages/chain/src/helpers/last-block.ts
+++ b/packages/chain/src/helpers/last-block.ts
@@ -1,0 +1,61 @@
+import { Codec } from '@leofcoin/codec-format-interface'
+import { BlockMessage, LastBlockMessage } from '@leofcoin/messages'
+
+const MAX_RESPONSE_DEPTH = 3
+
+const asLastBlockMessage = async (blockInput: unknown, claimedHash?: string): Promise<LastBlockMessage> => {
+  const block = new BlockMessage(blockInput as any)
+  const hash = await block.hash()
+
+  if (claimedHash && hash !== claimedHash) {
+    throw new Error(`lastBlock hash mismatch: expected ${claimedHash}, got ${hash}`)
+  }
+
+  return new LastBlockMessage({ hash, index: block.decoded.index })
+}
+
+const resolveLegacyHash = async (hash: string): Promise<LastBlockMessage> => {
+  const blockData = await (globalThis as any).peernet?.get?.(hash, 'block')
+  if (!blockData) throw new Error(`unable to resolve lastBlock hash: ${hash}`)
+  return asLastBlockMessage(blockData, hash)
+}
+
+/** Resolve current and legacy lastBlock responses to the canonical { hash, index } message. */
+export const resolveLastBlockMessage = async (result: unknown, depth = 0): Promise<LastBlockMessage> => {
+  if (depth > MAX_RESPONSE_DEPTH) throw new Error('lastBlock response nesting exceeds limit')
+
+  if (result instanceof Uint8Array) {
+    let codec: Codec | undefined
+    try {
+      codec = new Codec(result)
+    } catch {}
+
+    if (codec) {
+      if (codec.name === 'peernet-response') {
+        const ResponseMessage = (globalThis as any).peernet?.protos?.['peernet-response']
+        if (!ResponseMessage) throw new Error('peernet-response codec is not registered')
+
+        const wrapped = new ResponseMessage(result)
+        if (wrapped?.decoded?.response === undefined) throw new Error('peernet-response has no response payload')
+        return resolveLastBlockMessage(wrapped.decoded.response, depth + 1)
+      }
+
+      if (codec.name === 'last-block-message') return new LastBlockMessage(result)
+      if (codec.name === 'block-message') return asLastBlockMessage(result)
+    }
+
+    const candidate = new TextDecoder().decode(result)
+    if (candidate) return resolveLegacyHash(candidate)
+  }
+
+  if (typeof result === 'string') return resolveLegacyHash(result)
+
+  if (result && typeof result === 'object') {
+    const response = (result as any).decoded?.response ?? (result as any).response
+    if (response !== undefined) return resolveLastBlockMessage(response, depth + 1)
+    if ('hash' in result && 'index' in result) return new LastBlockMessage(result as any)
+    if ('previousHash' in result && 'index' in result) return asLastBlockMessage(result)
+  }
+
+  throw new Error(`invalid lastBlock payload: ${typeof result}`)
+}

--- a/packages/chain/src/state.ts
+++ b/packages/chain/src/state.ts
@@ -14,6 +14,7 @@ import { nativeToken } from '@leofcoin/addresses'
 import Jobber from './jobs/jobber.js'
 import { BlockHash, BlockInMemory, RawBlock } from './types.js'
 import { ResolveError, isExecutionError, isResolveError } from '@leofcoin/errors'
+import { resolveLastBlockMessage } from './helpers/last-block.js'
 
 declare type SyncState = 'syncing' | 'synced' | 'errored' | 'connectionless'
 declare type ChainState = 'loading' | 'loaded'
@@ -67,47 +68,6 @@ export default class State extends Contract {
 
   get resolving() {
     return this.#resolving
-  }
-
-  async #resolveLastBlockMessage(result: unknown) {
-    if (result instanceof Uint8Array) {
-      try {
-        let payload: unknown = result
-        for (let i = 0; i < 3; i += 1) {
-          try {
-            const wrapped = await new globalThis.peernet.protos['peernet-response'](payload)
-            if (wrapped?.decoded?.response === undefined) break
-            payload = wrapped.decoded.response
-          } catch {
-            break
-          }
-        }
-        if (payload !== result) return this.#resolveLastBlockMessage(payload)
-
-        return new LastBlockMessage(result)
-      } catch {
-        const candidate = new TextDecoder().decode(result)
-        if (candidate) {
-          const blockData = await globalThis.peernet.get(candidate, 'block')
-          if (blockData) return new BlockMessage(blockData)
-        }
-      }
-    }
-
-    if (typeof result === 'string') {
-      const blockData = await globalThis.peernet.get(result, 'block')
-      if (blockData) return new BlockMessage(blockData)
-    }
-
-    if (result && typeof result === 'object') {
-      const response = (result as any).decoded?.response ?? (result as any).response
-      if (response !== undefined) return this.#resolveLastBlockMessage(response)
-      if ('hash' in result && 'index' in result) {
-        return new LastBlockMessage(result)
-      }
-    }
-
-    throw new Error(`invalid lastBlock payload: ${typeof result}`)
   }
 
   get contracts() {
@@ -743,7 +703,7 @@ export default class State extends Contract {
     console.log({ promises })
     promises = await Promise.all(
       promises.map(async (item) => ({
-        value: (await this.#resolveLastBlockMessage(item.value)).decoded,
+        value: (await resolveLastBlockMessage(item.value)).decoded,
         peer: item.peer
       }))
     )

--- a/packages/chain/test/unit/last-block-response.test.js
+++ b/packages/chain/test/unit/last-block-response.test.js
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { FormatInterface } from '@leofcoin/codec-format-interface'
+import { BlockMessage, LastBlockMessage } from '@leofcoin/messages'
+import { resolveLastBlockMessage } from '../../src/helpers/last-block.ts'
+
+class ResponseMessage extends FormatInterface {
+  constructor(buffer) {
+    super(buffer, { response: new Uint8Array() }, { name: 'peernet-response' })
+  }
+}
+
+const blockInput = {
+  index: 9n,
+  previousHash: 'BA5PREVIOUS',
+  timestamp: 1_785_703_291_262,
+  reward: 150n,
+  fees: 0n,
+  transactions: [],
+  validators: [{ address: 'validator', reward: 150n }],
+  producer: 'validator',
+  producerProof: 'proof',
+  protocolVersion: '0.2.0'
+}
+
+test.beforeEach(() => {
+  globalThis.peernet = {
+    protos: { 'peernet-response': ResponseMessage },
+    get: async () => undefined
+  }
+})
+
+test.afterEach(() => {
+  delete globalThis.peernet
+})
+
+test('decodes a direct lastBlock message without treating it as a response envelope', async () => {
+  const encoded = new LastBlockMessage({ hash: 'BA5CURRENT', index: 9n }).encoded
+  const warnings = []
+  const originalWarn = console.warn
+  console.warn = (...args) => warnings.push(args)
+
+  try {
+    const resolved = await resolveLastBlockMessage(encoded)
+    assert.deepEqual(resolved.decoded, { hash: 'BA5CURRENT', index: 9n })
+    assert.deepEqual(warnings, [])
+  } finally {
+    console.warn = originalWarn
+  }
+})
+
+test('unwraps an encoded peernet response exactly once', async () => {
+  const lastBlock = new LastBlockMessage({ hash: 'BA5WRAPPED', index: 10n })
+  const response = new ResponseMessage({ response: lastBlock.encoded })
+
+  const resolved = await resolveLastBlockMessage(response.encoded)
+  assert.deepEqual(resolved.decoded, { hash: 'BA5WRAPPED', index: 10n })
+})
+
+test('normalizes a legacy full block response to hash and index', async () => {
+  const block = new BlockMessage(blockInput)
+  const resolved = await resolveLastBlockMessage(block.encoded)
+
+  assert.equal(resolved.decoded.hash, await block.hash())
+  assert.equal(resolved.decoded.index, 9n)
+})


### PR DESCRIPTION
## What changed

- decode only payloads whose codec is actually `peernet-response` as response envelopes
- normalize direct `LastBlockMessage`, wrapped responses, and legacy full-block responses to the canonical `{ hash, index }` shape
- share the resolver between chain peer sync and state sync
- reject mismatched hashes when resolving legacy hash-only responses

## Root cause

The request layer had already removed the outer response envelope. The last-block resolver then decoded the remaining `last-block-message` bytes as another `peernet-response`. The permissive proto decoder printed a length mismatch but returned a full `BlockMessage`; because that decoded object has no stored `hash` field, peer sync subsequently reported that the peer had no last block.

## Validation

- new last-block wire-format tests: 3/3 passing
- chain tests: 28/28 passing
- `npm run build:core` passing

The existing TypeScript warnings emitted by other packages during the core build remain unchanged.
