### PR TITLE
Add two-node chain sync E2E

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
         run: npm test
 
       - name: Run multi-process E2E tests
-        run: node --test test/e2e/*.test.mjs
+        run: node --test test/e2e/*.test.js

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,7 @@
       "problemMatcher": []
     },
     {
-      "label": "Leofcoin: Four-node E2E",
+      "label": "Leofcoin: Multi-node E2E",
       "type": "shell",
       "command": "npm run test:e2e",
       "group": {

--- a/packages/chain/src/helpers/response.ts
+++ b/packages/chain/src/helpers/response.ts
@@ -1,0 +1,43 @@
+import { Codec } from '@leofcoin/codec-format-interface'
+
+const MAX_RESPONSE_DEPTH = 3
+
+/** Remove only verified peernet-response envelopes and decode JSON payloads. */
+export const decodeResponsePayload = async (result: unknown, depth = 0): Promise<unknown> => {
+  if (depth > MAX_RESPONSE_DEPTH) throw new Error('peernet response nesting exceeds limit')
+
+  if (result instanceof Uint8Array) {
+    let codec: Codec | undefined
+    try {
+      codec = new Codec(result)
+    } catch {}
+
+    if (codec?.name === 'peernet-response') {
+      const ResponseMessage = (globalThis as any).peernet?.protos?.['peernet-response']
+      if (!ResponseMessage) throw new Error('peernet-response codec is not registered')
+      const wrapped = new ResponseMessage(result)
+      return decodeResponsePayload(wrapped.decoded.response, depth + 1)
+    }
+
+    try {
+      return JSON.parse(new TextDecoder().decode(result))
+    } catch {
+      return result
+    }
+  }
+
+  if (result && typeof result === 'object') {
+    const response = (result as any).decoded?.response ?? (result as any).response
+    if (response !== undefined) return decodeResponsePayload(response, depth + 1)
+  }
+
+  if (typeof result === 'string') {
+    try {
+      return JSON.parse(result)
+    } catch {
+      return result
+    }
+  }
+
+  return result
+}

--- a/packages/chain/src/state.ts
+++ b/packages/chain/src/state.ts
@@ -15,6 +15,7 @@ import Jobber from './jobs/jobber.js'
 import { BlockHash, BlockInMemory, RawBlock } from './types.js'
 import { ResolveError, isExecutionError, isResolveError } from '@leofcoin/errors'
 import { resolveLastBlockMessage } from './helpers/last-block.js'
+import { decodeResponsePayload } from './helpers/response.js'
 
 declare type SyncState = 'syncing' | 'synced' | 'errored' | 'connectionless'
 declare type ChainState = 'loading' | 'loaded'
@@ -660,21 +661,9 @@ export default class State extends Contract {
         compatiblePeerCount += 1
         const task = async () => {
           try {
-            let result = await peer.request(node.encoded)
+            const result = await peer.request(node.encoded)
             const resultType = result instanceof Uint8Array ? `bytes:${result.length}` : typeof result
             debug(`lastBlock result type: ${resultType}`)
-            console.log({ result })
-            if (result instanceof Uint8Array) {
-              for (let i = 0; i < 3; i += 1) {
-                try {
-                  const wrapped = await new globalThis.peernet.protos['peernet-response'](result)
-                  if (wrapped?.decoded?.response === undefined) break
-                  result = wrapped.decoded.response
-                } catch {
-                  break
-                }
-              }
-            }
             return { result, peer }
           } catch (error) {
             const peerId = (peer as any)?.peerId || (peer as any)?.id || (peer as any)?.address || 'unknown'
@@ -730,10 +719,11 @@ export default class State extends Contract {
         })
         let node = await globalThis.peernet.prepareMessage(data)
         try {
-          let message = await peer.request(node.encoded)
-          message = await new globalThis.peernet.protos['peernet-response'](message)
+          const message = await decodeResponsePayload(await peer.request(node.encoded))
+          const blocks = (message as any)?.blocks
+          if (!Array.isArray(blocks)) throw new Error('knownBlocks response does not contain a blocks array')
           const MAX_WANTLIST_SIZE = 1000
-          const incoming = message.decoded.response.blocks.filter((block) => !this.knownBlocks.includes(block))
+          const incoming = blocks.filter((block) => !this.knownBlocks.includes(block))
           const remaining = MAX_WANTLIST_SIZE - this.wantList.length
           if (remaining > 0) this.wantList.push(...incoming.slice(0, remaining))
         } catch (error) {
@@ -865,31 +855,24 @@ export default class State extends Contract {
     return true
   }
 
-  promiseRequests(promises) {
-    return new Promise(async (resolve, reject) => {
-      const timeout = setTimeout(() => {
-        resolve([{ index: 0, hash: '0x0' }])
-        debug('sync timed out')
-      }, this.requestTimeout)
-      console.log({ promises })
-      promises = await Promise.allSettled(promises)
-      console.log({ promises })
-      promises = promises.filter(({ status }) => status === 'fulfilled')
+  async promiseRequests(promises) {
+    let timeout
+    const settled = await Promise.race([
+      Promise.allSettled(promises),
+      new Promise((resolve) => {
+        timeout = setTimeout(() => resolve(null), this.requestTimeout)
+      })
+    ])
+    clearTimeout(timeout)
 
-      clearTimeout(timeout)
+    if (settled === null) {
+      debug('sync timed out')
+      return []
+    }
 
-      if (promises.length > 0) {
-        promises = promises.map(async ({ value }) => {
-          const node = await new globalThis.peernet.protos['peernet-response'](value.result)
-          return { value: node.decoded.response, peer: value.peer }
-        })
-        promises = await Promise.all(promises)
-
-        resolve(promises)
-      } else {
-        resolve([])
-      }
-    })
+    return settled
+      .filter(({ status }) => status === 'fulfilled')
+      .map(({ value }) => ({ value: value.result, peer: value.peer }))
   }
 
   get canSync() {

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -6,11 +6,11 @@ Run the local four-process bootstrap and restart gate with:
 npm run test:e2e
 ```
 
-In GitHub Codespaces or VS Code, this is also available from **Tasks: Run Test Task** as **Leofcoin: Four-node E2E**. The repository's dev container pins Node 22 and installs dependencies during Codespace creation.
+In GitHub Codespaces or VS Code, this is also available from **Tasks: Run Test Task** as **Leofcoin: Multi-node E2E**. The repository's dev container pins Node 22 and installs dependencies during Codespace creation.
 
-This creates isolated temporary homes, starts a local discovery star plus four real node and chain processes, verifies full peer discovery and the empty bootstrap state, restarts one process, verifies identity persistence and reconnection, and always removes the temporary data.
+This creates isolated temporary homes and a local discovery star. It verifies the existing four-node bootstrap/restart lifecycle and a two-node chain-sync flow where a late node discovers a source node, requests `lastBlock` and `knownBlocks` through the real transport, fetches two canonical fixture blocks, converges on the same persisted state snapshot, and retains that state after restart. Temporary data is always removed.
 
-This is a lifecycle, storage-isolation, and peer-connectivity gate. It does not yet prove block production or consensus convergence.
+This is a lifecycle, storage-isolation, peer-connectivity, wire-format, cold-sync, and restart-recovery gate. Fixture blocks are signed and hash-linked but inserted by the harness, so this test does not claim to prove validator election, quorum, or live consensus block production.
 
 ## Remote lifecycle smoke test
 

--- a/test/e2e/network.test.js
+++ b/test/e2e/network.test.js
@@ -96,7 +96,12 @@ class TestNode {
       const timeout = setTimeout(
         () => {
           cleanup()
-          reject(new Error(`node ${this.index} timed out waiting for ${type}\n${this.stderr}`))
+          reject(
+            new Error(
+              `node ${this.index} timed out waiting for ${type}`
+                + `\nstdout=${this.stdout.slice(-8_000)}\nstderr=${this.stderr.slice(-8_000)}`
+            )
+          )
         },
         30_000
       )
@@ -123,9 +128,17 @@ class TestNode {
   }
 
   async status() {
+    return this.command('status', 'status')
+  }
+
+  async command(command, eventType) {
     const afterIndex = this.events.length
-    this.process.stdin.write('status\n')
-    return this.waitFor('status', afterIndex)
+    this.process.stdin.write(`${command}\n`)
+    return this.waitFor(eventType, afterIndex)
+  }
+
+  appendBlock() {
+    return this.command('append-block', 'block:produced')
   }
 
   async waitForPeers(minimum, timeoutMs = 20_000) {
@@ -138,6 +151,26 @@ class TestNode {
     }
     throw new Error(
       `node ${this.index} did not reach ${minimum} connected peers; last status=${JSON.stringify(current)}`
+        + `\nstdout=${this.stdout.slice(-4_000)}\nstderr=${this.stderr.slice(-4_000)}`
+    )
+  }
+
+  async waitForTip({ hash, index }, timeoutMs = 30_000) {
+    const deadline = Date.now() + timeoutMs
+    let current
+    while (Date.now() < deadline) {
+      current = await this.status()
+      if (
+        current.lastBlock?.hash === hash &&
+        Number(current.lastBlock?.index) === Number(index) &&
+        current.chain?.sync === 'synced'
+      ) {
+        return current
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+    throw new Error(
+      `node ${this.index} did not sync tip ${hash}@${index}; last status=${JSON.stringify(current)}`
         + `\nstdout=${this.stdout.slice(-4_000)}\nstderr=${this.stderr.slice(-4_000)}`
     )
   }
@@ -182,6 +215,49 @@ test('four isolated nodes converge on bootstrap state and survive restart', { ti
     assert.equal(after.account, before.account)
     assert.deepEqual(after.chain, { sync: 'connectionless', chain: 'loaded' })
     await nodes[0].waitForPeers(3)
+  } finally {
+    await Promise.allSettled(nodes.map((node) => node.stop()))
+    star.kill('SIGKILL')
+    await Promise.all(homes.map((home) => rm(home, { recursive: true, force: true })))
+  }
+})
+
+test('a late node cold-syncs canonical blocks and keeps them across restart', { timeout: 90_000 }, async () => {
+  const homes = await Promise.all(
+    Array.from({ length: 2 }, (_, index) => mkdtemp(join(tmpdir(), `leofcoin-sync-e2e-${index}-`)))
+  )
+  const port = await availablePort()
+  const star = await startStar(port)
+  const starUrl = `ws://127.0.0.1:${port}`
+  const nodes = homes.map((home, index) => new TestNode(home, index, starUrl))
+
+  try {
+    await nodes[0].start()
+    const first = await nodes[0].appendBlock()
+    const tip = await nodes[0].appendBlock()
+    assert.equal(first.index, 0)
+    assert.equal(tip.index, 1)
+
+    const source = await nodes[0].status()
+    assert.equal(source.lastBlock.hash, tip.hash)
+    assert.equal(Number(source.lastBlock.index), tip.index)
+    assert.deepEqual(source.blockHashes.sort(), [first.hash, tip.hash].sort())
+
+    await nodes[1].start()
+    await waitForStarPeers(star, 2)
+    await Promise.all(nodes.map((node) => node.waitForPeers(1)))
+    const synced = await nodes[1].waitForTip(tip)
+    assert.deepEqual(synced.blockHashes, source.blockHashes)
+    assert.equal(synced.stateSnapshot, source.stateSnapshot)
+
+    await nodes[1].stop()
+    nodes[1] = new TestNode(homes[1], 1, starUrl)
+    const restarted = await nodes[1].start()
+    assert.equal(restarted.lastBlock.hash, tip.hash)
+    assert.equal(Number(restarted.lastBlock.index), tip.index)
+    assert.deepEqual(restarted.blockHashes, source.blockHashes)
+    assert.equal(restarted.stateSnapshot, source.stateSnapshot)
+    await nodes[1].waitForPeers(1)
   } finally {
     await Promise.allSettled(nodes.map((node) => node.stop()))
     star.kill('SIGKILL')

--- a/test/e2e/node-process.js
+++ b/test/e2e/node-process.js
@@ -1,4 +1,5 @@
-const emit = (type, value = {}) => process.stdout.write(`E2E_EVENT:${JSON.stringify({ type, ...value })}\n`)
+const stringify = (value) => JSON.stringify(value, (_, item) => (typeof item === 'bigint' ? item.toString() : item))
+const emit = (type, value = {}) => process.stdout.write(`E2E_EVENT:${stringify({ type, ...value })}\n`)
 
 for (const event of ['uncaughtException', 'unhandledRejection']) {
   process.on(event, (error) => {
@@ -33,6 +34,53 @@ const { default: Chain } = await import('../../packages/chain/exports/chain.js')
 const chain = new Chain({ network: 'leofcoin:e2e', networkVersion: 'e2e' })
 await chain.ready
 
+const { BlockMessage } = await import('@leofcoin/messages')
+const { signTransaction } = await import('@leofcoin/lib')
+const { default: addresses } = await import('@leofcoin/addresses')
+
+const storeText = async (store, key) => {
+  if (!(await store.has(key))) return null
+  return new TextDecoder().decode(await store.get(key))
+}
+
+const appendFixtureBlock = async () => {
+  const previous = await chain.lastBlock
+  const index = Number(previous?.index ?? -1) + 1
+  const producer = globalThis.peernet.selectedAccount
+  const timestamp = Date.now()
+  const block = {
+    index,
+    previousHash: previous?.hash || '0x0',
+    timestamp,
+    reward: 150n,
+    fees: 0n,
+    transactions: [],
+    validators: [{ address: producer, reward: 150n }],
+    producer,
+    producerProof: '',
+    protocolVersion: chain.version
+  }
+  const unsignedBlockHash = await new BlockMessage(block).hash()
+  const proof = await signTransaction(
+    {
+      from: producer,
+      to: addresses.validators,
+      method: 'produceBlock',
+      params: [unsignedBlockHash],
+      timestamp
+    },
+    globalThis.peernet.identity
+  )
+  const encoded = new BlockMessage({ ...block, producerProof: proof.signature }).encoded
+  const message = new BlockMessage(encoded)
+  const hash = await message.hash()
+
+  await globalThis.peernet.put(hash, message.encoded, 'block')
+  await chain.machine.addLoadedBlock({ ...message.decoded, hash, loaded: true })
+  await chain.updateState(message)
+  return { hash, index }
+}
+
 const status = async () => ({
   identity: globalThis.peernet.id,
   account: globalThis.peernet.selectedAccount,
@@ -43,7 +91,9 @@ const status = async () => ({
   discoveryEvents: discoveryEvents.length,
   discoverySubscribers: globalThis.pubsub.subscriberCount('peer:joined'),
   chain: chain.state,
-  lastBlock: await chain.lastBlock
+  lastBlock: await chain.lastBlock,
+  blockHashes: (await globalThis.blockStore.keys()).sort(),
+  stateSnapshot: await storeText(globalThis.stateStore, 'lastBlock')
 })
 
 emit('ready', await status())
@@ -51,6 +101,7 @@ process.stdin.setEncoding('utf8')
 process.stdin.on('data', async (input) => {
   for (const command of input.trim().split(/\s+/)) {
     if (command === 'status') emit('status', await status())
+    if (command === 'append-block') emit('block:produced', await appendFixtureBlock())
     if (command === 'shutdown') {
       emit('stopped')
       process.exit(0)


### PR DESCRIPTION
## What changed

- add a real two-node, multi-process cold-sync and restart-recovery scenario
- create two signed, hash-linked, canonically encoded fixture blocks on the source node
- verify the late node discovers its peer, requests `lastBlock` and `knownBlocks`, fetches both blocks, converges on the same persisted state, and retains it after restart
- expose block hashes and the persisted state marker through the E2E process protocol for deterministic assertions
- run the existing `.test.js` E2E suite in GitHub Actions (the workflow previously targeted the nonexistent `*.test.mjs` glob)
- rename the VS Code task to `Leofcoin: Multi-node E2E`

## Bugs found by the new gate

The E2E test exposed two remaining state-sync response bugs after #119:

1. `State.#getLatestBlock` still decoded a verified `last-block-message` as another `peernet-response` before calling the shared resolver.
2. The state-sync `knownBlocks` path assumed `response.blocks` was already an object, although the response payload can be encoded JSON bytes.

Responses are now unwrapped only when their codec is actually `peernet-response`; JSON payloads are decoded explicitly, and request timeout handling no longer invents a malformed fallback response.

## Validation

- full multi-process E2E: 2/2 passing in ~23 seconds
  - four-node bootstrap, isolation, reconnect and restart
  - late-node cold sync, matching tip/block set/state snapshot and restart persistence
- messages: 5/5 passing
- chain: 28/28 passing
- core build passing

Fixture blocks are signed, hash-linked and canonically encoded, but inserted by the harness. This gate proves transport and state sync; it does not claim to prove live validator election or quorum block production.
