### PR TITLE
Validate block proposals before voting

### DIFF
--- a/packages/chain/src/chain.ts
+++ b/packages/chain/src/chain.ts
@@ -28,6 +28,7 @@ import VersionControl from './version-control.js'
 import ConnectionMonitor from './connection-monitor.js'
 import { quorumThreshold } from './consensus/quorum.js'
 import { validateChainLink } from './consensus/chain-link.js'
+import { resolveTransactionReference } from './consensus/transaction-reference.js'
 import { signConsensusMessage, verifyConsensusMessage } from './consensus/signature.js'
 import { nextBlockIndex, proposalDelay } from './consensus/cadence.js'
 import { compareTransactionNonces, pruneCanonicalTransactions } from './consensus/transaction-pool.js'
@@ -262,6 +263,17 @@ export default class Chain extends VersionControl {
         )
       }
     }
+  }
+
+  async #resolveBlockTransactions(blockMessage: BlockMessage): Promise<TransactionMessage[]> {
+    return Promise.all(
+      blockMessage.decoded.transactions.map(async (expectedHash) => {
+        const data = await globalThis.peernet.get(expectedHash, 'transaction')
+        const transaction = await resolveTransactionReference(expectedHash, data)
+        await this.validateTransactionSignature(transaction)
+        return transaction
+      })
+    )
   }
 
   /** Check if the next block will cross an epoch boundary (block-based timing) */
@@ -549,8 +561,25 @@ export default class Chain extends VersionControl {
           debug(`[consensus] Block hash mismatch in proposal: expected ${blockHash}, got ${actualHash}`)
           return
         }
+
+        if (BigInt(blockMessage.decoded.index) !== index) {
+          debug(`[consensus] Proposal height ${index} does not match block height ${blockMessage.decoded.index}`)
+          return
+        }
+        if (blockMessage.decoded.producer !== from) {
+          debug(`[consensus] Proposal sender ${from} does not match block producer ${blockMessage.decoded.producer}`)
+          return
+        }
+
+        validateChainLink(localBlock, {
+          index: Number(blockMessage.decoded.index),
+          hash: actualHash,
+          previousHash: String(blockMessage.decoded.previousHash)
+        })
+        await this.#validateBlockValidators(blockMessage)
+        await this.#resolveBlockTransactions(blockMessage)
       } catch (e) {
-        debug(`[consensus] Cannot fetch proposed block ${blockHash}:`, (e as Error)?.message)
+        debug(`[consensus] Invalid proposed block ${blockHash}:`, (e as Error)?.message)
         return
       }
 
@@ -1148,18 +1177,9 @@ export default class Chain extends VersionControl {
     await this.#validateBlockValidators(blockMessage)
 
     // NOW SAFE TO PROCEED with transaction processing
-    const transactions = await Promise.all(
-      blockMessage.decoded.transactions
-        // @ts-ignore
-        .map(async (hash) => {
-          const data = await peernet.get(hash, 'transaction')
-          return new TransactionMessage(data)
-        })
-    )
-
-    // Authenticate every referenced transaction before storing the block or
-    // mutating the local transaction pool.
-    await Promise.all(transactions.map((transaction) => this.validateTransactionSignature(transaction)))
+    // Authenticate both the content-addressed reference and transaction sender
+    // before storing the block or mutating the local transaction pool.
+    const transactions = await this.#resolveBlockTransactions(blockMessage)
     await Promise.all(
       blockMessage.decoded.transactions.map(async (transactionHash) => {
         if (await transactionPoolStore.has(transactionHash)) await transactionPoolStore.delete(transactionHash)

--- a/packages/chain/src/consensus/transaction-reference.ts
+++ b/packages/chain/src/consensus/transaction-reference.ts
@@ -1,0 +1,16 @@
+import { TransactionMessage } from '@leofcoin/messages'
+
+export const resolveTransactionReference = async (
+  expectedHash: string,
+  transactionData: Uint8Array | TransactionMessage
+): Promise<TransactionMessage> => {
+  const transaction =
+    transactionData instanceof TransactionMessage ? transactionData : new TransactionMessage(transactionData)
+  const actualHash = await transaction.hash()
+
+  if (actualHash !== expectedHash) {
+    throw new Error(`Transaction hash mismatch: expected ${expectedHash}, got ${actualHash}`)
+  }
+
+  return transaction
+}

--- a/packages/chain/test/unit/transaction-reference.test.js
+++ b/packages/chain/test/unit/transaction-reference.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { TransactionMessage } from '@leofcoin/messages'
+
+import { resolveTransactionReference } from '../../src/consensus/transaction-reference.ts'
+
+const transaction = {
+  from: 'sender',
+  to: 'receiver',
+  method: 'transfer',
+  params: ['sender', 'receiver', 1n],
+  timestamp: 1,
+  nonce: 1,
+  signature: 'signature'
+}
+
+test('accepts transaction bytes that match the block reference', async () => {
+  const message = new TransactionMessage(transaction)
+  const hash = await message.hash()
+
+  const resolved = await resolveTransactionReference(hash, message.encoded)
+
+  assert.equal(await resolved.hash(), hash)
+  assert.equal(resolved.decoded.from, transaction.from)
+  assert.equal(resolved.decoded.nonce, transaction.nonce)
+})
+
+test('rejects valid transaction bytes served for a different block reference', async () => {
+  const message = new TransactionMessage(transaction)
+
+  await assert.rejects(
+    resolveTransactionReference('BA5XWRONGTRANSACTIONREFERENCE', message.encoded),
+    /Transaction hash mismatch/
+  )
+})


### PR DESCRIPTION
## Summary

- validate the proposed block height, producer, chain link, validator set, producer proof, rewards, and referenced transactions before casting a prevote
- enforce content-address integrity by checking fetched transaction bytes against every hash recorded in a block
- reuse the same transaction-reference validation during canonical block commit
- add regression coverage for matching and mismatched transaction references

## Consensus invariant

A validator must never vote for a proposal it could not safely commit, and a block may never resolve a transaction hash to different signed transaction bytes.

## Verification

- `npm test --workspace=@leofcoin/chain` (27/27)
- `npm run build:core`
- `npm run test:e2e`: complete build passed; local network phase could not bind `127.0.0.1` in the Codex sandbox (`EPERM`), so CI must execute the socket-based E2E
